### PR TITLE
fixing problem with removing the "Icon" directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,8 @@ web/sites/simpletest
 .DS_Store*
 ehthumbs.db
 Icon
+!web/core/lib/Drupal/Core/Layout/Icon
+!web/core/lib/Drupal/Core/Layout/Icon/*
 
 Thumbs.db
 ._*


### PR DESCRIPTION
`core/lib/Drupal/Core/Layout/` has an "Icon" directory in it.
The added two lines make sure it isn't removed.